### PR TITLE
Issue fixed: missing ".war" extension in .ppf file.

### DIFF
--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -380,7 +380,7 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
     	if(!project.getPackaging().equalsIgnoreCase("war"))
     		return "";
     	
-    	return Utils.makeRelative(webappDirectory, projectDir);
+    	return Utils.makeRelative(webappDirectory, projectDir) + ".war";
     }
 	
 	private void configureVariables() throws OunceCoreException, ComponentLookupException {


### PR DESCRIPTION
For maven project that produces a .war file, fix the issue of web_context_root_path missing ".war" extension in generated .ppf file.